### PR TITLE
added_access_token_and_changed_avatar_image_size

### DIFF
--- a/app/controllers/api/v1/oauths_controller.rb
+++ b/app/controllers/api/v1/oauths_controller.rb
@@ -8,28 +8,37 @@ module Api
       def callback
         provider = auth_params[:provider]
         if auth_params[:denied].present?
-          redirect_to root_path, notice: 'ログインをキャンセルしました。'
+          redirect_to root_path
           return
         end
-        if (@user = login_from(provider))
-          redirect_to root_path, notice: "#{provider.titleize}ログインしました。"
+        if (user = login_from(provider))
+          user.authentication.update!(
+            access_token: access_token.token,
+            access_token_secret: access_token.secret
+          )
         else
-          begin
-            @user = create_from(provider)
-            reset_session
-            auto_login(@user)
-          rescue StandardError
-            redirect_to root_path, alert: "#{provider.titleize}ログインに失敗しました。"
-          end
-          cookies[:logged_in] = { value: 1, expires: 10.minute.from_now }
-          redirect_to root_path, notice: "#{provider.titleize}ログインしました。"
+          fetch_user_data_from(provider)
         end
+        redirect_to root_path
       end
 
       private
 
       def auth_params
         params.permit(:code, :provider, :denied, :format, :oauth_token, :oauth_verifier)
+      end
+
+      def fetch_user_data_from(provider)
+        user_from_provider = build_from(provider)
+        user = User.find_or_initialize_by(twitter_id: user_from_provider.twitter_id)
+        user = user_from_provider if user.new_record?
+        user.build_authentication(uid: @user_hash[:uid],
+                                  provider: provider,
+                                  access_token: access_token.token,
+                                  access_token_secret: access_token.secret)
+        user.save!
+        reset_session
+        auto_login(@user)
       end
     end
   end

--- a/app/dashboards/authentication_dashboard.rb
+++ b/app/dashboards/authentication_dashboard.rb
@@ -12,6 +12,8 @@ class AuthenticationDashboard < Administrate::BaseDashboard
     id: Field::Number,
     provider: Field::String,
     uid: Field::String,
+    access_token: Field::String,
+    access_token_secret: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
   }.freeze
@@ -26,6 +28,8 @@ class AuthenticationDashboard < Administrate::BaseDashboard
     id
     provider
     uid
+    access_token
+    access_token_secret
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -46,6 +50,8 @@ class AuthenticationDashboard < Administrate::BaseDashboard
     user
     provider
     uid
+    access_token
+    access_token_secret
   ].freeze
 
   # COLLECTION_FILTERS

--- a/app/javascript/components/TheHeader.vue
+++ b/app/javascript/components/TheHeader.vue
@@ -15,7 +15,7 @@
             </a>
             <button @click="isOpen = !isOpen">
               <img
-                :src="currentUser.image" class='object-cover border-2 rounded-full h-16 w-16'  v-if="currentUser"
+                :src="currentUser.image" class='border-2 rounded-full w-16 h-16'  v-if="currentUser"
               >
             </button>
           </div>

--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -1,6 +1,15 @@
 class Authentication < ApplicationRecord
+  before_save :encrypt_access_token
   belongs_to :user
 
   validates :uid, presence: true
   validates :provider, presence: true
+
+  def encrypt_access_token
+    key_len = ActiveSupport::MessageEncryptor.key_len
+    secret = Rails.application.key_generator.generate_key('salt', key_len)
+    crypt = ActiveSupport::MessageEncryptor.new(secret)
+    self.access_token = crypt.encrypt_and_sign(access_token)
+    self.access_token_secret = crypt.encrypt_and_sign(access_token_secret)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  before_save :modify_avatar_url
   authenticates_with_sorcery!
 
   has_one :authentication, dependent: :destroy
@@ -12,4 +13,10 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 50 }
   validates :screen_name, presence: true
   validates :role, presence: true
+
+  private
+
+  def modify_avatar_url
+    image&.sub!(/_normal(.jpg|.jpeg|.gif|.png)/i) { Regexp.last_match[1] }
+  end
 end

--- a/db/migrate/20220711082116_add_access_token_to_authentications.rb
+++ b/db/migrate/20220711082116_add_access_token_to_authentications.rb
@@ -1,0 +1,6 @@
+class AddAccessTokenToAuthentications < ActiveRecord::Migration[6.0]
+  def change
+    add_column :authentications, :access_token, :string, null: false, default: ''
+    add_column :authentications, :access_token_secret, :string, null: false, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_26_055034) do
+ActiveRecord::Schema.define(version: 2022_07_11_082116) do
 
   create_table "authentications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -18,6 +18,8 @@ ActiveRecord::Schema.define(version: 2022_06_26_055034) do
     t.string "uid", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "access_token", default: "", null: false
+    t.string "access_token_secret", default: "", null: false
     t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
   end
 


### PR DESCRIPTION
## 概要
○Twitter認証時にaccess_tokenも保存するように変更。
・DBにaccess_tokenとaccess_token_secretのカラムを追加。
・oauchControllerの修正。
・authenticationモデルにDB保存前にaccess_tokenとaccess_token_secretを暗号化するメソッドを追加。
○Twitter認証時のユーザー画像サイズがデフォルトの小さい画像のままだったため、表示される画像が荒い状態となっていた。
・userモデルに画像のurlから末尾のnormalを削除するメソッドを追加して、大きい画像を取得できるように変更。

## コメント
ユーザー画像がきれいになりました。
