### PR TITLE
Close Header Menu

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -3,7 +3,7 @@
     class="d-flex flex-column bg-cover bg-fixed bg-center"
     :style="{ backgroundImage: 'url(' + image_src + ')' }"
   >
-    <TheHeader class="mb-auto sticky top-0" />
+    <TheHeader class="mb-auto sticky top-0 z-10" />
     <transition>
       <TheFlash v-if="flash.message" />
     </transition>

--- a/app/javascript/components/HeaderMenu.vue
+++ b/app/javascript/components/HeaderMenu.vue
@@ -1,0 +1,76 @@
+<template>
+  <div>
+    <div
+      v-if="currentUser"
+      v-show="isVisibleHeaderMenu"
+      class="flex flex-col mt-3 justify-between"
+    >
+      <button
+        class="p-2 lg:px-4 text-2xl text-center border border-transparent rounded hover:bg-red-100 hover:text-red-700 transition-colors duration-300"
+      >
+        <router-link :to="`/users/${currentUser.screen_name}`">
+          マイページ
+        </router-link>
+      </button>
+      <button
+        class="p-2 lg:px-4 text-2xl text-center border border-transparent rounded hover:bg-red-100 hover:text-red-700 transition-colors duration-300"
+      >
+        <router-link to="/previous">
+          過去の診断結果
+        </router-link>
+      </button>
+      <button
+        class="p-2 lg:px-4 text-2xl text-center border border-transparent rounded hover:bg-red-100 hover:text-red-700 transition-colors duration-300"
+        @click="logout"
+      >
+        ログアウト
+      </button>
+    </div>
+  </div>
+</template>
+
+<script>
+import { mapGetters　} from "vuex"
+export default {
+  props: {
+    isVisibleHeaderMenu: {
+      type: Boolean,
+      required: true
+    }
+  },
+  computed: {
+    ...mapGetters(
+      'users', ['currentUser' , 'isAuthenticatedUser']
+    ),
+    currentPath() {
+      return this.$route.path
+    },
+  },
+  watch: {
+    currentPath: function() {
+      this.closeHeaderMenu()
+    }
+  },
+  methods: {
+    async logout() {
+      await this.$store.dispatch('users/logoutUser')
+      try {
+        this.$router.push('/'),
+        this.$store.dispatch('flash/fetchFlash', {
+          type: 'alert',
+          message: 'ログアウトしました。'
+        })
+      }
+      catch (err) {
+        console.log(err.response)
+      }
+    },
+    closeHeaderMenu(){
+      this.$emit("close-menu");
+    },
+  },
+}
+</script>
+
+<style scoped>
+</style>

--- a/app/javascript/components/TheHeader.vue
+++ b/app/javascript/components/TheHeader.vue
@@ -37,7 +37,6 @@
         >
           <button
             class="p-2 lg:px-4 text-2xl text-center border border-transparent rounded hover:bg-red-100 hover:text-red-700 transition-colors duration-300"
-            @click="closeMenu"
           >
             <router-link :to="`/users/${currentUser.screen_name}`">
               マイページ
@@ -45,7 +44,6 @@
           </button>
           <button
             class="p-2 lg:px-4 text-2xl text-center border border-transparent rounded hover:bg-red-100 hover:text-red-700 transition-colors duration-300"
-            @click="closeMenu"
           >
             <router-link to="/previous">
               過去の診断結果
@@ -64,7 +62,6 @@
 </template>
 
 <script>
-import Cookies from 'js-cookie'
 import { mapGetters　} from "vuex"
 
 export default {
@@ -80,6 +77,9 @@ export default {
     ...mapGetters(
       'users', ['currentUser' , 'isAuthenticatedUser']
     ),
+    currentPath() {
+      return this.$route.path
+    },
     logo_src() {
       return require("../../../public/images/topLogo.png")
     },
@@ -104,7 +104,12 @@ export default {
     closeMenu(){
       this.isOpen = false;
     },
-  }
+  },
+   watch: {
+    currentPath: function() {
+      this.closeMenu()
+    }
+  },
 }
 </script>
 

--- a/app/javascript/components/TheHeader.vue
+++ b/app/javascript/components/TheHeader.vue
@@ -10,7 +10,6 @@
             <img
               :src="logo_src"
               width="120px"
-              @click="closeMenu"
             >
           </router-link>
           <div class="item">
@@ -21,7 +20,10 @@
             >
               Twitter認証によるユーザー登録
             </a>
-            <button @click="isOpen = !isOpen">
+            <button
+              v-click-outside="handleCloseHeaderMenu"
+              @click="openHeaderMenu"
+            >
               <img
                 v-if="currentUser"
                 :src="currentUser.image"
@@ -30,56 +32,36 @@
             </button>
           </div>
         </div>
-        <div
-          v-if="currentUser"
-          :class="isOpen ? 'flex' : 'hidden'"
-          class="flex-col mt-3 justify-between"
-        >
-          <button
-            class="p-2 lg:px-4 text-2xl text-center border border-transparent rounded hover:bg-red-100 hover:text-red-700 transition-colors duration-300"
-          >
-            <router-link :to="`/users/${currentUser.screen_name}`">
-              マイページ
-            </router-link>
-          </button>
-          <button
-            class="p-2 lg:px-4 text-2xl text-center border border-transparent rounded hover:bg-red-100 hover:text-red-700 transition-colors duration-300"
-          >
-            <router-link to="/previous">
-              過去の診断結果
-            </router-link>
-          </button>
-          <button
-            class="p-2 lg:px-4 text-2xl text-center border border-transparent rounded hover:bg-red-100 hover:text-red-700 transition-colors duration-300"
-            @click="logout"
-          >
-            ログアウト
-          </button>
-        </div>
+        <HeaderMenu
+          :is-visible-header-menu="isVisibleHeaderMenu"
+          @close-menu="handleCloseHeaderMenu"
+        />
       </div>
     </nav>
   </header>
 </template>
 
 <script>
+import HeaderMenu from "./HeaderMenu"
 import { mapGetters　} from "vuex"
+import ClickOutside from "vue-click-outside"
 
 export default {
-  name: 'TheHeader',
+  directives: {
+    ClickOutside
+  },
   components: {
+    HeaderMenu
   },
   data() {
     return {
-      isOpen: false,
+      isVisibleHeaderMenu: false,
     }
   },
   computed: {
     ...mapGetters(
       'users', ['currentUser' , 'isAuthenticatedUser']
     ),
-    currentPath() {
-      return this.$route.path
-    },
     logo_src() {
       return require("../../../public/images/topLogo.png")
     },
@@ -101,13 +83,11 @@ export default {
         console.log(err.response)
       }
     },
-    closeMenu(){
-      this.isOpen = false;
+    openHeaderMenu(){
+      this.isVisibleHeaderMenu = true;
     },
-  },
-   watch: {
-    currentPath: function() {
-      this.closeMenu()
+    handleCloseHeaderMenu() {
+      this.isVisibleHeaderMenu = false;
     }
   },
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "vee-validate": "^3.4.13",
     "vue": "^2.6.14",
     "vue-chartjs": "3.5.1",
+    "vue-click-outside": "^1.1.0",
     "vue-gtag": "^1.16.1",
     "vue-loader": "15.9.2",
     "vue-router": "^3.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8345,6 +8345,11 @@ vue-chartjs@3.5.1:
   dependencies:
     "@types/chart.js" "^2.7.55"
 
+vue-click-outside@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/vue-click-outside/-/vue-click-outside-1.1.0.tgz#48b7680b518923e701643cccb3e165854aad99eb"
+  integrity sha512-pNyvAA9mRXJwPHlHJyjMb4IONSc7khS5lxGcMyE2EIKgNMAO279PWM9Hyq0d5J4FkiSRdmFLwnbjDd5UtPizHQ==
+
 vue-eslint-parser@^9.0.1:
   version "9.0.3"
   resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-9.0.3.tgz#0c17a89e0932cc94fa6a79f0726697e13bfe3c96"


### PR DESCRIPTION
## 概要
○メニューかアイコン以外の場所をクリックして別のページに遷移するとヘッダーメニューが開いたままになっていたので、ページ遷移時に閉まるように変更。
○メニュー部分をコンポーネント(HeaderMenu)に切り分け。
○アイコン以外の場所をクリックするとメニューが閉じるように変更。

## コメント
アイコンをクリックしたときもメニューを閉じるようにしたい。
