### PR TITLE
added_analysis_button_without_entering_ID_while_login

### DIFF
--- a/app/javascript/pages/TheTop.vue
+++ b/app/javascript/pages/TheTop.vue
@@ -27,23 +27,80 @@
               </span>
             </ValidationProvider>
           </div>
-          <div class="my-32 justify-center">
+          <div
+            v-show="currentUser === null"
+            class="my-32 justify-center"
+          >
             <button
               v-show="!isLoading"
               :disabled="invalid"
-              class="bg-red-400 hover:bg-red-600 rounded p-1"
+              class="bg-red-400 hover:bg-red-600 rounded p-1 w-72"
               @click="startAnalysis(targetAccount)"
             >
-              <p class="bg-red-500 hover:bg-red-700 text-white font-bold text-4xl rounded w-64 px-8 py-8 inline-flex justify-center">
+              <p class="bg-red-500 hover:bg-red-700 text-white font-bold text-4xl rounded h-28 justify-center items-center flex">
                 診断する
               </p>
             </button>
             <button
               v-show="isLoading"
               :disabled="invalid"
-              class="bg-red-400 hover:bg-red-600 rounded p-1"
+              class="bg-red-400 hover:bg-red-600 rounded p-1 w-72"
             >
-              <div class="bg-red-500 hover:bg-red-700 rounded w-64 px-10 py-8 inline-flex justify-between items-center">
+              <div class="bg-red-500 hover:bg-red-700 rounded px-12 h-28 justify-between items-center flex">
+                <spinner
+                  :size="30"
+                  color="#ffffff"
+                />
+                <p class="text-white font-bold text-4xl ">
+                  診断中‥
+                </p>
+              </div>
+            </button>
+          </div>
+          <div
+            v-show="currentUser !== null"
+            class="my-32 flex justify-between"
+          >
+            <button
+              v-show="!isLoading"
+              :disabled="invalid"
+              class="bg-red-400 hover:bg-red-600 rounded p-1 w-72"
+              @click="startAnalysis(targetAccount)"
+            >
+              <p class="bg-red-500 hover:bg-red-700 text-white font-bold text-3xl rounded h-28 justify-center items-center flex">
+                IDを入力して<br>診断する
+              </p>
+            </button>
+            <button
+              v-show="isLoading"
+              :disabled="invalid"
+              class="bg-red-400 hover:bg-red-600 rounded p-1 w-72"
+            >
+              <div class="bg-red-500 hover:bg-red-700 rounded h-28 px-12 justify-between items-center flex">
+                <spinner
+                  :size="30"
+                  color="#ffffff"
+                />
+                <p class="text-white font-bold text-4xl ">
+                  診断中‥
+                </p>
+              </div>
+            </button>
+            <button
+              v-show="!isLoading"
+              class="bg-red-400 hover:bg-red-600 rounded p-1 w-72"
+              @click="analyzeMyself"
+            >
+              <p class="bg-red-500 hover:bg-red-700 text-white font-bold text-3xl rounded h-28 justify-center items-center flex">
+                自分のアカウント<br>で診断する
+              </p>
+            </button>
+            <button
+              v-show="isLoading"
+              :disabled="invalid"
+              class="bg-red-400 hover:bg-red-600 rounded p-1 w-72"
+            >
+              <div class="bg-red-500 hover:bg-red-700 rounded h-28 px-12 justify-between items-center flex">
                 <spinner
                   :size="30"
                   color="#ffffff"
@@ -55,13 +112,15 @@
             </button>
           </div>
           <div class="my-32 justify-center">
-            <button class=" bg-red-400 hover:bg-red-600 rounded p-1">
-              <router-link
-                to="/help"
-                class="bg-red-500 hover:bg-red-700 text-white font-bold text-4xl rounded w-64 px-8 py-8 inline-flex justify-center"
-              >
-                使い方
-              </router-link>
+            <button class=" bg-red-400 hover:bg-red-600 rounded p-1 w-72">
+              <div class="bg-red-500 hover:bg-red-700 rounded h-28 justify-center items-center flex">
+                <router-link
+                  to="/help"
+                  class=" text-white font-bold text-4xl"
+                >
+                  使い方
+                </router-link>
+              </div>
             </button>
           </div>
         </ValidationObserver>
@@ -109,6 +168,28 @@ export default {
   methods: {
     async startAnalysis() {
       const target_account = this.targetAccount
+      const user_id = (this.currentUser !== null) ? this.currentUser.id : 0
+      this.isLoading = true
+      await axios.post('/api/v1/results', {
+        target_account: target_account,
+        user_id: user_id
+      })
+        .then(res => {
+          this.$store.commit("results/setResult", res.data),
+          this.isLoading = false,
+          this.$router.push('/result')
+        })
+        .catch(error => {
+          console.log(error.response)
+          this.isLoading = false
+          this.$store.dispatch('flash/fetchFlash', {
+            type: 'alert',
+            message: error.response.data.error.title
+          })
+        })
+    },
+    async analyzeMyself() {
+      const target_account = this.currentUser.screen_name
       const user_id = (this.currentUser !== null) ? this.currentUser.id : 0
       this.isLoading = true
       await axios.post('/api/v1/results', {


### PR DESCRIPTION
## 概要
○レビュー会で指摘のあった、「ログイン中、自分のアカウントについてはIDを入力しなくても診断できると良いかも」という意見をうけ、ログイン中は「IDを入力して診断するボタン」と、「IDを入力せずに自分のアカウントを診断するボタン」を追加。

## コメント
issueに追加したが、Topがbuttonだらけになって可読性が落ちてきたのでコンポーネントに分けるか、tailwindをカスタマイズするかした方が良さそう。
