### PR TITLE
removed_vue_click_outside

### DIFF
--- a/app/javascript/components/HeaderMenu.vue
+++ b/app/javascript/components/HeaderMenu.vue
@@ -7,6 +7,7 @@
     >
       <button
         class="p-2 lg:px-4 text-2xl text-center border border-transparent rounded hover:bg-red-100 hover:text-red-700 transition-colors duration-300"
+        @click="closeHeaderMenu"
       >
         <router-link :to="`/users/${currentUser.screen_name}`">
           マイページ
@@ -14,6 +15,7 @@
       </button>
       <button
         class="p-2 lg:px-4 text-2xl text-center border border-transparent rounded hover:bg-red-100 hover:text-red-700 transition-colors duration-300"
+        @click="closeHeaderMenu"
       >
         <router-link to="/previous">
           過去の診断結果

--- a/app/javascript/components/TheHeader.vue
+++ b/app/javascript/components/TheHeader.vue
@@ -21,8 +21,7 @@
               Twitter認証によるユーザー登録
             </a>
             <button
-              v-click-outside="handleCloseHeaderMenu"
-              @click="openHeaderMenu"
+              @click="isVisibleHeaderMenu = !isVisibleHeaderMenu"
             >
               <img
                 v-if="currentUser"
@@ -44,12 +43,8 @@
 <script>
 import HeaderMenu from "./HeaderMenu"
 import { mapGetters　} from "vuex"
-import ClickOutside from "vue-click-outside"
 
 export default {
-  directives: {
-    ClickOutside
-  },
   components: {
     HeaderMenu
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "vee-validate": "^3.4.13",
     "vue": "^2.6.14",
     "vue-chartjs": "3.5.1",
-    "vue-click-outside": "^1.1.0",
     "vue-gtag": "^1.16.1",
     "vue-loader": "15.9.2",
     "vue-router": "^3.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8345,11 +8345,6 @@ vue-chartjs@3.5.1:
   dependencies:
     "@types/chart.js" "^2.7.55"
 
-vue-click-outside@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/vue-click-outside/-/vue-click-outside-1.1.0.tgz#48b7680b518923e701643cccb3e165854aad99eb"
-  integrity sha512-pNyvAA9mRXJwPHlHJyjMb4IONSc7khS5lxGcMyE2EIKgNMAO279PWM9Hyq0d5J4FkiSRdmFLwnbjDd5UtPizHQ==
-
 vue-eslint-parser@^9.0.1:
   version "9.0.3"
   resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-9.0.3.tgz#0c17a89e0932cc94fa6a79f0726697e13bfe3c96"


### PR DESCRIPTION
## 概要
○ヘッダーメニュー以外の場所をクリックした際にメニューを閉じられるようにしたはいいが、スマホの方だと上手く機能していないようでメニューを開けなくなっていた。そのため、vue_click_outsideは外して、ページ遷移が行われた際に閉じる状態に戻した。

## コメント
メニュー以外の場所をクリックして閉じるようにする変更はまた後日(優先度低め)。
