### PR TITLE
Added Screen Name To Results

### DIFF
--- a/app/controllers/api/v1/results_controller.rb
+++ b/app/controllers/api/v1/results_controller.rb
@@ -8,7 +8,9 @@ module Api
         render json: @results, include: [:dragon], status: 200
       end
 
-      def index
+      def last_result
+        @results = Result.includes(:dragon).where(screen_name: params[:id]).order(created_at: :desc).limit(2)
+        render json: @results, include: [:dragon], status: 200
       end
 
       def show

--- a/app/controllers/api/v1/results_controller.rb
+++ b/app/controllers/api/v1/results_controller.rb
@@ -38,7 +38,7 @@ module Api
       end
 
       def result_params
-        params.require(:result).permit(:user_id, :dragon_id, :score, :magnitude, :troversion, :target_account)
+        params.require(:result).permit(:user_id, :dragon_id, :score, :magnitude, :troversion, :target_account, :screen_name)
       end
 
     end

--- a/app/dashboards/result_dashboard.rb
+++ b/app/dashboards/result_dashboard.rb
@@ -17,6 +17,7 @@ class ResultDashboard < Administrate::BaseDashboard
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     target_account: Field::String,
+    screen_name: Field::String,
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -31,6 +32,7 @@ class ResultDashboard < Administrate::BaseDashboard
     score
     magnitude
     troversion
+    screen_name
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -45,6 +47,7 @@ class ResultDashboard < Administrate::BaseDashboard
     created_at
     updated_at
     target_account
+    screen_name
   ].freeze
 
   # FORM_ATTRIBUTES
@@ -57,6 +60,7 @@ class ResultDashboard < Administrate::BaseDashboard
     magnitude
     troversion
     target_account
+    screen_name
   ].freeze
 
   # COLLECTION_FILTERS

--- a/app/javascript/components/TheFooter.vue
+++ b/app/javascript/components/TheFooter.vue
@@ -24,6 +24,14 @@
               href="https://twitter.com/Umesho0415"
               class="p-2 rounded text-white hover:bg-twitterBlue"
             >
+              お問い合わせ
+            </a>
+          </li>
+          <li class="my-2 px-4">
+            <a
+              href="https://twitter.com"
+              class="p-2 rounded text-white hover:bg-twitterBlue"
+            >
               <i class="ri-twitter-fill" />
             </a>
           </li>

--- a/app/javascript/components/UserRadar.vue
+++ b/app/javascript/components/UserRadar.vue
@@ -1,0 +1,135 @@
+<script>
+import { Radar } from 'vue-chartjs'
+
+export default {
+  extends: Radar,
+  props: {
+    results: {
+      // type: Object,
+      // required: true,
+    }
+  },
+  data() {
+    return {
+      latestResult: {
+        type: Array,
+        required: true
+      },
+      formerResult: {
+        type: Array,
+        required: true
+      },
+    }
+  },
+  computed: {
+    chartData() {
+      return {
+        labels: [ 'ポジティブ度', '感情の強さ', '活発度' ],
+        datasets: [
+          {
+            label: '最新の診断結果',
+            data: this.latestResult,
+            backgroundColor: 'rgba(255, 99, 132, 0.6)',
+            borderColor: 'rgb(255, 99, 132)',
+            pointBackgroundColor: 'rgb(255, 99, 132)',
+            pointBorderColor: '#fff',
+            pointHoverBackgroundColor: '#fff',
+            pointHoverBorderColor: 'rgb(255, 99, 132)',
+          },
+          {
+            label: '一つ前の診断結果',
+            data: this.formerResult,
+            backgroundColor: 'rgba(0, 172, 237, 0.7)',
+            borderColor: 'rgb(0, 172, 237)',
+            pointBackgroundColor: 'rgb(0, 172, 237)',
+            pointBorderColor: '#fff',
+            pointHoverBackgroundColor: '#fff',
+            pointHoverBorderColor: 'rgb(0, 172, 237)',
+          },
+        ]
+      }
+    },
+    chartOptions() {
+      return {
+        responsive: true,
+        maintainAspectRatio: false,
+        tooltips: {
+        },
+        legend: {
+          display: true,
+          position: 'bottom',
+          labels: {
+            fontSize: 18,
+            fontColor: 'white',
+            fontStyle: 'bold',
+          }
+        },
+        animation:{
+          duration: 1500,
+          easing: 'easeInOutCubic'
+        },
+        scale: {
+          ticks: {
+            display: false,
+            max: 100,
+            min: 0,
+          },
+          gridLines: {
+            color: 'white',
+          },
+          angleLines: {
+            color: 'white',
+          },
+          pointLabels: {
+            fontSize: 20,
+            fontColor: '#ffffff',
+            fontStyle: 'bold',
+          },
+        }
+      }
+    }
+  },
+  watch: {
+    results: function() {
+      this.adjustData(),
+      this.renderChart(this.chartData, this.chartOptions)
+    }
+  },
+  // mounted(){
+  //   this.adjustData(),
+  //   this.renderChart(this.chartData, this.chartOptions)
+  // },
+  methods: {
+    adjustData() {
+      let latestScore = this.adjustScore(this.results[0].score)
+      let latestMagnitude = this.adjustMagnitude(this.results[0].magnitude)
+      let latestTroversion = this.adjustTroversion(this.results[0].troversion)
+      this.latestResult = [ latestScore, latestMagnitude, latestTroversion ];
+      let formerScore = this.adjustScore(this.results[1].score)
+      let formerMagnitude = this.adjustMagnitude(this.results[1].magnitude)
+      let formerTroversion = this.adjustTroversion(this.results[1].troversion)
+      this.formerResult = [ formerScore, formerMagnitude, formerTroversion ];
+    },
+    adjustScore(score) {
+      return Math.trunc( ( score + 1 ) / 2 * 100 );
+    },
+    adjustMagnitude(magnitude) {
+      if ( magnitude < 1.14 ) {
+        return Math.trunc( ( magnitude ) / 1.14 * 100 );
+      } else {
+        return 100;
+      };
+    },
+    adjustTroversion(troversion) {
+      if ( troversion < 0.74 ) {
+        return Math.trunc( ( troversion ) / 0.74 * 100 );
+      } else {
+        return 100;
+      };
+    },
+  }
+}
+</script>
+
+<style scoped>
+</style>

--- a/app/javascript/pages/PreviousResults.vue
+++ b/app/javascript/pages/PreviousResults.vue
@@ -69,10 +69,6 @@ export default {
     ...mapGetters(
       'users', ['currentUser']
     ),
-    dragon_image_src() {
-      const result = this.results[0]
-        return require("../../../public/images/"  + result.dragon.image)
-    },
     filteredResults() {
       return this.filterResults();
     }

--- a/app/javascript/pages/PreviousResults.vue
+++ b/app/javascript/pages/PreviousResults.vue
@@ -6,9 +6,16 @@
           {{ title }}
         </div>
       </div>
+      <div class="col-start-2 col-span-10 mt-5 ">
+        <input
+          v-model="keyword"
+          class="h-12 bg-gray-100 text-2xl p-2 rounded-lg border-4 border-indigo-500 shadow-md focus:outline-none focus:border-indigo-600 w-full"
+          placeholder="検索したいワードを入力"
+        >
+      </div>
       <div class="items-center col-start-2 col-span-10">
         <div
-          v-for="result in results"
+          v-for="result in filteredResults"
           :key="result.id"
           class="w-full mx-auto bg-white hover:bg-gray-200 shadow-md rounded-md my-12"
         >
@@ -54,7 +61,8 @@ export default {
   data() {
     return {
       title: "過去の診断結果",
-      results: {}
+      results: {},
+      keyword: "",
     };
   },
   computed: {
@@ -65,6 +73,9 @@ export default {
       const result = this.results[0]
         return require("../../../public/images/"  + result.dragon.image)
     },
+    filteredResults() {
+      return this.filterResults();
+    }
   },
   mounted() {
     this.fetchResults()
@@ -80,6 +91,16 @@ export default {
       let created_at = dayjs(date).format('YYYY-MM-DD');
       return created_at;
     },
+    filterResults() {
+      let filtered = [];
+      for (let i in this.results) {
+        let result = this.results[i];
+        if (result.target_account.includes(this.keyword) || result.dragon.name.includes(this.keyword) || result.screen_name.includes(this.keyword)) {
+          filtered.push(result);
+        }
+      }
+      return filtered;
+    }
   }
 }
 </script>

--- a/app/javascript/pages/PreviousShow.vue
+++ b/app/javascript/pages/PreviousShow.vue
@@ -3,14 +3,14 @@
     <div class="grid grid-cols-12 gap-10 md:pt-20 md:pb-10">
       <div class="col-start-2 col-span-10 mt-20 md:mt-0">
         <div
-          v-if="result"
+          v-show="result"
           class="text-2xl inline p-2 text-white font-bold border-b-8 border-white md:text-4xl"
         >
           {{ shortenedName }}さんの心に潜むドラゴンは…
         </div>
       </div>
       <div
-        v-if="result"
+        v-show="result"
         class="text-center text-white col-start-2 col-span-10 px-10 pb-10 mx-auto"
       >
         <div class="text-6xl font-bold">
@@ -79,18 +79,13 @@ export default {
   },
   data() {
     return {
-      result: {
-        type: Object,
-        required: true,
-      }
+      result: {}
     }
   },
   computed: {
-    dragon_image_src() {
-        return require("../../../public/images/" + this.result.dragon.image)
-    },
     shortenedName(){
-      return this.result.target_account.length > 8 ? this.result.target_account.substring(0,8) + '...' : this.result.target_account;
+      let name = this.result.target_account
+      return name.length > 8 ? name.substring(0,8) + '...' : name;
     },
     currentPath() {
       return this.$route.path

--- a/app/javascript/pages/TheResult.vue
+++ b/app/javascript/pages/TheResult.vue
@@ -90,8 +90,9 @@ export default {
     ...mapGetters(
       'results', ['results']
     ),
-    shortenedName(){
-      return this.results.target_account.length > 8 ? this.results.target_account.substring(0,8) + '...' : this.results.target_account;
+    shortenedName() {
+      let name = this.results.target_account;
+      return name.length > 8 ? name.substring(0,8) + '...' : name;
     },
     dragon_image_src() {
       return require("../../../public/images/" + this.results.dragon.image)

--- a/app/javascript/pages/TheUser.vue
+++ b/app/javascript/pages/TheUser.vue
@@ -3,7 +3,7 @@
     <div class="grid grid-cols-12 gap-10 md:pt-20">
       <div class="col-start-2 col-span-10 mt-20 md:mt-0">
         <div class="text-3xl inline p-2 text-white font-bold border-b-8 border-white md:text-4xl">
-          {{ title }}
+          マイページ
         </div>
       </div>
       <div class="items-center col-start-2 col-span-10">
@@ -12,6 +12,12 @@
           @update-Settings="updateUserSettings"
           @logout="deleteUser"
         />
+        <div v-show="results" class="mb-4">
+          <UserRadar
+            :style="chartStyles"
+            :results="results"
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -21,15 +27,20 @@
 import axios from 'axios';
 import { mapGetters } from 'vuex'
 import UserProfileCard from '../components/UserProfileCard';
+import UserRadar from '../components/UserRadar.vue';
 
 export default {
   components: {
     UserProfileCard,
+    UserRadar,
   },
   data() {
     return {
-      title: "マイページ",
-    };
+      results: {
+        // type: Object,
+        // required: true,
+      }
+    }
   },
   computed: {
     ...mapGetters(
@@ -38,19 +49,26 @@ export default {
     currentPath() {
       return this.$route.path
     },
+    chartStyles() {
+      return {
+        'margin-left': 'auto',
+        'margin-right': 'auto',
+        height: '510px',
+      }
+    }
   },
   watch: {
     currentPath: function() {
-      this.fetchUser()
+      this.fetchResults()
     }
   },
   mounted() {
-    this.fetchUser()
+    this.fetchResults()
   },
   methods: {
-    async fetchUser() {
-     const res = await axios.get(`/api/v1/users/${this.$route.params.twitter_id}`)
-     this.user = res.data
+    async fetchResults() {
+     const res = await axios.get(`/api/v1/results/${this.$route.params.id}/last_result`)
+     this.results = res.data
     },
     async updateUserSettings() {
       await axios.patch("/api/v1/user_settings")

--- a/app/serializers/result_serializer.rb
+++ b/app/serializers/result_serializer.rb
@@ -1,5 +1,5 @@
 class ResultSerializer < ActiveModel::Serializer
-  attributes :id, :dragon_id, :user_id, :target_account, :score, :magnitude, :troversion, :created_at
+  attributes :id, :dragon_id, :user_id, :target_account, :screen_name, :score, :magnitude, :troversion, :created_at
 
   belongs_to :dragon
 end

--- a/app/services/analyze_account_service.rb
+++ b/app/services/analyze_account_service.rb
@@ -27,6 +27,7 @@ class AnalyzeAccountService
     end
     user_id = @user
     target_account = @target.name
+    screen_name = '@' + @target.screen_name
     score = ( resultScore.sum(0.0) / resultScore.size ).floor(2)
     magnitude = ( resultMagnitude.sum(0.0) / resultMagnitude.size ).floor(2)
     troversion = CalculateTroversionService.new(@target, @tweets).call
@@ -35,10 +36,11 @@ class AnalyzeAccountService
     {
       user_id: user_id,
       dragon_id: dragon_id,
+      target_account: target_account,
+      screen_name: screen_name,
       score: score,
       magnitude: magnitude,
       troversion: troversion,
-      target_account: target_account
     }
   end
 end

--- a/app/services/analyze_account_service.rb
+++ b/app/services/analyze_account_service.rb
@@ -27,7 +27,7 @@ class AnalyzeAccountService
     end
     user_id = @user
     target_account = @target.name
-    screen_name = '@' + @target.screen_name
+    screen_name = @target.screen_name
     score = ( resultScore.sum(0.0) / resultScore.size ).floor(2)
     magnitude = ( resultMagnitude.sum(0.0) / resultMagnitude.size ).floor(2)
     troversion = CalculateTroversionService.new(@target, @tweets).call

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,8 +16,9 @@ Rails.application.routes.draw do
       get 'oauth/:provider', to: 'oauths#oauth', as: :auth_at_provider
       delete 'logout', to: 'user_sessions#destroy'
       resources :accounts, only: %i[index create show]
-      resources :results, only: %i[index create show] do
+      resources :results, only: %i[create show] do
         member do
+          get 'last_result'
           get 'previous_results'
         end
       end

--- a/db/migrate/20220724072651_add_screen_name_to_results.rb
+++ b/db/migrate/20220724072651_add_screen_name_to_results.rb
@@ -1,0 +1,5 @@
+class AddScreenNameToResults < ActiveRecord::Migration[6.0]
+  def change
+    add_column :results, :screen_name, :string, null: false, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_11_082116) do
+ActiveRecord::Schema.define(version: 2022_07_24_072651) do
 
   create_table "authentications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 2022_07_11_082116) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "target_account", null: false
+    t.string "screen_name", default: "", null: false
     t.index ["dragon_id"], name: "index_results_on_dragon_id"
     t.index ["user_id"], name: "index_results_on_user_id"
   end


### PR DESCRIPTION
## 概要
○screen_nameをresultに追加。
○screen_nameを検索条件として、ユーザーページに最新の診断結果とその１つ前の診断結果のレーダーチャートを表示するように。
○フッターのtwitterマークのリンク先は作者(自分)のアカウントになっていたが、作者のリンクは「問い合わせ」リンクに変更して、それとは別にtwitterマークのリンクはtwitterのホームに飛ぶリンクを追加。
○幾つかのページの余計な記述を削除。

## コメント
チーム開発する時は実装した機能や行ったこと別にコミットを分けると同時に、プルリクも分けていく必要があるんだろうな。
と思いつつ全く別の作業を同じプルリクでマージする私。
