### PR TITLE
Loading Spinner and Twitter Link(fixed on the page of bottom)

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -4,7 +4,7 @@
     :style="{ backgroundImage: 'url(' + image_src + ')' }"
   >
     <TheHeader class="mb-auto sticky top-0 z-10" />
-    <transition>
+    <transition name="fade">
       <TheFlash v-if="flash.message" />
     </transition>
     <transition mode="out-in">

--- a/app/javascript/components/SpinnerModal.vue
+++ b/app/javascript/components/SpinnerModal.vue
@@ -1,0 +1,47 @@
+<template>
+  <div
+    v-show="isVisibleSpinnerModal"
+    class="relative z-10"
+  >
+    <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity">
+    </div>
+    <div class="fixed z-10 inset-0 overflow-y-auto">
+      <div class="flex items-end sm:items-center justify-center min-h-full p-4 text-center sm:p-0">
+        <div class="relative rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:max-w-lg sm:w-full">
+          <div class="bg-red-400 p-1">
+            <div class="bg-red-500 rounded px-40 h-32 justify-between items-center flex">
+              <spinner
+                :size="30"
+                color="#ffffff"
+              />
+              <p class="text-white font-bold text-4xl ">
+                診断中‥
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import Spinner from 'vue-spinner-component/src/Spinner.vue'
+
+export default ({
+  components: {
+    Spinner,
+  },
+  props: {
+    isVisibleSpinnerModal: {
+      type: Boolean,
+      required: true
+    }
+  },
+  methods: {
+  }
+})
+</script>
+
+<style scoped>
+</style>

--- a/app/javascript/components/SpinnerModal.vue
+++ b/app/javascript/components/SpinnerModal.vue
@@ -1,10 +1,9 @@
 <template>
   <div
-    v-show="isVisibleSpinnerModal"
+    v-if="isVisibleSpinnerModal"
     class="relative z-10"
   >
-    <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity">
-    </div>
+    <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
     <div class="fixed z-10 inset-0 overflow-y-auto">
       <div class="flex items-end sm:items-center justify-center min-h-full p-4 text-center sm:p-0">
         <div class="relative rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:max-w-lg sm:w-full">

--- a/app/javascript/components/TheFooter.vue
+++ b/app/javascript/components/TheFooter.vue
@@ -27,14 +27,14 @@
               お問い合わせ
             </a>
           </li>
-          <li class="my-2 px-4">
+          <!-- <li class="my-2 px-4">
             <a
               href="https://twitter.com"
               class="p-2 rounded text-white hover:bg-twitterBlue"
             >
               <i class="ri-twitter-fill" />
             </a>
-          </li>
+          </li> -->
         </ul>
         <div class="text-center text-xl p-2 font-light flex items-center justify-center">
           ©2022 Dratter

--- a/app/javascript/components/TwitterLink.vue
+++ b/app/javascript/components/TwitterLink.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="fixed z-10 bottom-8 right-8 overflow-y-auto">
+    <div class="rounded-full w-16 h-16 bg-twitterBlue  hover:bg-blue-700 flex justify-center items-center text-white">
+      <a
+        href="https://twitter.com"
+        target="_blank"
+        style="font-size: 28px;"
+      >
+        <i class="ri-twitter-fill" />
+      </a>
+    </div>
+  </div>
+</template>
+
+<script>
+
+export default ({
+
+})
+</script>
+
+<style scoped>
+</style>

--- a/app/javascript/pages/TheTop.vue
+++ b/app/javascript/pages/TheTop.vue
@@ -27,12 +27,14 @@
               </span>
             </ValidationProvider>
           </div>
+          <SpinnerModal
+            :is-visible-spinner-modal="isVisibleSpinnerModal"
+          />
           <div
             v-show="currentUser === null"
             class="my-32 justify-center"
           >
             <button
-              v-show="!isLoading"
               :disabled="invalid"
               class="bg-red-400 hover:bg-red-600 rounded p-1 w-72"
               @click="startAnalysis(targetAccount)"
@@ -41,28 +43,12 @@
                 診断する
               </p>
             </button>
-            <button
-              v-show="isLoading"
-              :disabled="invalid"
-              class="bg-red-400 hover:bg-red-600 rounded p-1 w-72"
-            >
-              <div class="bg-red-500 hover:bg-red-700 rounded px-12 h-28 justify-between items-center flex">
-                <spinner
-                  :size="30"
-                  color="#ffffff"
-                />
-                <p class="text-white font-bold text-4xl ">
-                  診断中‥
-                </p>
-              </div>
-            </button>
           </div>
           <div
             v-show="currentUser !== null"
             class="my-32 flex justify-between"
           >
             <button
-              v-show="!isLoading"
               :disabled="invalid"
               class="bg-red-400 hover:bg-red-600 rounded p-1 w-72"
               @click="startAnalysis(targetAccount)"
@@ -72,43 +58,12 @@
               </p>
             </button>
             <button
-              v-show="isLoading"
-              :disabled="invalid"
-              class="bg-red-400 hover:bg-red-600 rounded p-1 w-72"
-            >
-              <div class="bg-red-500 hover:bg-red-700 rounded h-28 px-12 justify-between items-center flex">
-                <spinner
-                  :size="30"
-                  color="#ffffff"
-                />
-                <p class="text-white font-bold text-4xl ">
-                  診断中‥
-                </p>
-              </div>
-            </button>
-            <button
-              v-show="!isLoading"
               class="bg-red-400 hover:bg-red-600 rounded p-1 w-72"
               @click="analyzeMyself"
             >
               <p class="bg-red-500 hover:bg-red-700 text-white font-bold text-3xl rounded h-28 justify-center items-center flex">
                 自分のアカウント<br>で診断する
               </p>
-            </button>
-            <button
-              v-show="isLoading"
-              :disabled="invalid"
-              class="bg-red-400 hover:bg-red-600 rounded p-1 w-72"
-            >
-              <div class="bg-red-500 hover:bg-red-700 rounded h-28 px-12 justify-between items-center flex">
-                <spinner
-                  :size="30"
-                  color="#ffffff"
-                />
-                <p class="text-white font-bold text-4xl ">
-                  診断中‥
-                </p>
-              </div>
             </button>
           </div>
           <div class="my-32 justify-center">
@@ -132,17 +87,17 @@
 <script>
 import axios from 'axios'
 import { mapGetters } from 'vuex'
-import Spinner from 'vue-spinner-component/src/Spinner.vue';
+import SpinnerModal from '../components/SpinnerModal.vue';
 
 export default {
   components: {
-    Spinner
+    SpinnerModal
   },
   data() {
     return {
       targetAccount: "",
-      isLoading: false,
       user_id: "",
+      isVisibleSpinnerModal: false,
     }
   },
   computed: {
@@ -169,19 +124,19 @@ export default {
     async startAnalysis() {
       const target_account = this.targetAccount
       const user_id = (this.currentUser !== null) ? this.currentUser.id : 0
-      this.isLoading = true
+      this.isVisibleSpinnerModal = true
       await axios.post('/api/v1/results', {
         target_account: target_account,
         user_id: user_id
       })
         .then(res => {
           this.$store.commit("results/setResult", res.data),
-          this.isLoading = false,
+          this.isVisibleSpinnerModal = false,
           this.$router.push('/result')
         })
         .catch(error => {
           console.log(error.response)
-          this.isLoading = false
+          this.isVisibleSpinnerModal = false
           this.$store.dispatch('flash/fetchFlash', {
             type: 'alert',
             message: error.response.data.error.title
@@ -191,28 +146,39 @@ export default {
     async analyzeMyself() {
       const target_account = this.currentUser.screen_name
       const user_id = (this.currentUser !== null) ? this.currentUser.id : 0
-      this.isLoading = true
+      this.isVisibleSpinnerModal = true
       await axios.post('/api/v1/results', {
         target_account: target_account,
         user_id: user_id
       })
         .then(res => {
           this.$store.commit("results/setResult", res.data),
-          this.isLoading = false,
+          this.isVisibleSpinnerModal = false,
           this.$router.push('/result')
         })
         .catch(error => {
           console.log(error.response)
-          this.isLoading = false
+          this.isVisibleSpinnerModal = false
           this.$store.dispatch('flash/fetchFlash', {
             type: 'alert',
             message: error.response.data.error.title
           })
         })
     },
+    openSpinnerModal() {
+      this.isVisibleSpinnerModal = true;
+    },
   },
 }
 </script>
 
 <style scoped>
+.spinner-enter-active,
+.spinner-fade-leave-active {
+    transition: opacity .3s ease;
+}
+.spinner-fade-enter,
+.spinner-fade-leave-to {
+    opacity: 0;
+}
 </style>

--- a/app/javascript/pages/TheTop.vue
+++ b/app/javascript/pages/TheTop.vue
@@ -27,9 +27,11 @@
               </span>
             </ValidationProvider>
           </div>
-          <SpinnerModal
-            :is-visible-spinner-modal="isVisibleSpinnerModal"
-          />
+          <transition name="spinner">
+            <SpinnerModal
+              :is-visible-spinner-modal="isVisibleSpinnerModal"
+            />
+          </transition>
           <div
             v-show="currentUser === null"
             class="my-32 justify-center"
@@ -79,6 +81,7 @@
             </button>
           </div>
         </ValidationObserver>
+        <TwitterLink />
       </div>
     </div>
   </div>
@@ -88,10 +91,12 @@
 import axios from 'axios'
 import { mapGetters } from 'vuex'
 import SpinnerModal from '../components/SpinnerModal.vue';
+import TwitterLink from '../components/TwitterLink.vue';
 
 export default {
   components: {
-    SpinnerModal
+    SpinnerModal,
+    TwitterLink,
   },
   data() {
     return {


### PR DESCRIPTION
## 概要
○診断待ち時のローディング画面がダサかったので、ローディング画面のモーダルを追加。
○トップページにTwitterへのリンクボタンが画面下に固定されていた方が使いやすいかと思い追加。
○ついでにフラッシュメッセージの表示にtransitionが効いてなかったので修正。

## コメント
ローディング画面のモーダル表示にtransitionが何故か効かない。
