### PR TITLE
delete_results_when_user_withdrew_app

### DIFF
--- a/app/javascript/components/UserRadar.vue
+++ b/app/javascript/components/UserRadar.vue
@@ -91,20 +91,19 @@ export default {
   },
   watch: {
     results: function() {
-      this.adjustData(),
+      this.adjustLatestData(),
+      this.adjustFormerData(),
       this.renderChart(this.chartData, this.chartOptions)
     }
   },
-  // mounted(){
-  //   this.adjustData(),
-  //   this.renderChart(this.chartData, this.chartOptions)
-  // },
   methods: {
-    adjustData() {
+    adjustLatestData() {
       let latestScore = this.adjustScore(this.results[0].score)
       let latestMagnitude = this.adjustMagnitude(this.results[0].magnitude)
       let latestTroversion = this.adjustTroversion(this.results[0].troversion)
       this.latestResult = [ latestScore, latestMagnitude, latestTroversion ];
+    },
+    adjustFormerData(){
       let formerScore = this.adjustScore(this.results[1].score)
       let formerMagnitude = this.adjustMagnitude(this.results[1].magnitude)
       let formerTroversion = this.adjustTroversion(this.results[1].troversion)

--- a/app/javascript/pages/TheUser.vue
+++ b/app/javascript/pages/TheUser.vue
@@ -70,8 +70,13 @@ export default {
   },
   methods: {
     async fetchResults() {
-     const res = await axios.get(`/api/v1/results/${this.$route.params.id}/last_result`)
-     this.results = res.data
+     await axios.get(`/api/v1/results/${this.$route.params.id}/last_result`)
+       .then(res => {
+        this.results = res.data
+       })
+       .catch(err => {
+        console.log(err.response)
+       })
     },
     async updateUserSettings() {
       await axios.patch("/api/v1/user_settings")

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -1,5 +1,5 @@
 class Result < ApplicationRecord
-  belongs_to :user, optional: true
+  belongs_to :user
   belongs_to :dragon
 
   validates :user_id, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
 
   has_one :authentication, dependent: :destroy
-  has_many :results
+  has_many :results, dependent: :destroy
 
   accepts_nested_attributes_for :authentication
 


### PR DESCRIPTION
## 概要
○退会した後にもう一度登録し直した場合、診断結果が削除されない様な設計になっているため、ユーザーページの過去の結果チャートに値が表示されてしまう状態になっていた。
○退会したユーザーのデータを残しておく必要も薄かったので、userからresultへのアソシエーションにdependent:destroyを追加。
○一緒にユーザーチャートのmethod周りを少し整理。

## コメント
現状アプリの機能には影響ないけど、developerコンソールで表示されるエラーがちょいちょいあるので直したいな。
