### PR TITLE
fixed_bug(not_displayed_toppage)

### DIFF
--- a/app/javascript/pages/TheTop.vue
+++ b/app/javascript/pages/TheTop.vue
@@ -139,7 +139,7 @@ export default {
   },
   methods: {
     fetchUserAndLevel() {
-      this.$store.dispatch("users/getCurrentUser", this.currentUser)
+     this.$store.dispatch("users/getCurrentUser", this.currentUser)
       this.$store.dispatch("levels/fetchLevel", this.currentUser.id)
     },
     async startAnalysis() {

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -1,7 +1,6 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
 import createPersistedState from 'vuex-persistedstate'
-import Cookies from 'js-cookie';
 
 import results from './modules/results'
 import dragons from './modules/dragons'
@@ -21,17 +20,8 @@ export default new Vuex.Store({
   },
   plugins: [
     createPersistedState({
-      storage: {
-        key: 'dratterApp',
-
-        paths: [
-          'users.currentUser'
-        ],
-        getItem: key => Cookies.get(key),
-        setItem: (key, value) =>
-          Cookies.set(key, value, { expires: 3, secure: true }),
-          removeItem: key => Cookies.remove(key),
-      },
+      key: 'dratterApp',
+      storage: window.sessionStorage,
     }),
   ],
 })

--- a/app/javascript/store/modules/dragons.js
+++ b/app/javascript/store/modules/dragons.js
@@ -1,7 +1,7 @@
 import axios from '../../plugins/axios.js';
 
 const state = {
-  dragons: []
+  dragons: ""
 }
 
 const getters = {

--- a/app/javascript/store/modules/levels.js
+++ b/app/javascript/store/modules/levels.js
@@ -1,7 +1,7 @@
 import axios from '../../plugins/axios.js';
 
 const state = {
-  levels: []
+  levels: ""
 }
 
 const getters = {
@@ -17,10 +17,12 @@ const mutations = {
 const actions = {
   fetchLevel ({ commit }, id) {
     axios.get(`/v1/levels/${id}`)
-    .then(res => {
-      commit('setLevel', res.data)
-    })
-    .catch(err => console.log(err.response));
+      .then(res => {
+        commit('setLevel', res.data)
+      })
+      .catch(err => {
+        return null
+      });
   },
   levelUp ({ commit }, id) {
     axios.get(`/v1/levels/${id}/levelup`)

--- a/app/javascript/store/modules/results.js
+++ b/app/javascript/store/modules/results.js
@@ -1,7 +1,7 @@
 import axios from '../../plugins/axios.js';
 
 const state = {
-  results: [],
+  results: "",
 }
 
 const getters = {

--- a/app/javascript/store/modules/users.js
+++ b/app/javascript/store/modules/users.js
@@ -1,7 +1,7 @@
 import axios from '../../plugins/axios.js';
 
 const state = {
-  currentUser: []
+  currentUser: ""
 }
 
 const getters = {


### PR DESCRIPTION
## 概要
トップページが表示されないバグを修正。
○原因
トップページのロゴを切り替える条件にvuexのcurrentUserの有無を指定したはいいが、vuexの初期値を空の配列にしたままだったので、常にcurrentUserが存在する状態になってしまっていた。
currentUserが存在していても、正規のUserデータは入っていないので上手く表示されず、ログアウトもできない状態になってしまっていた。

## コメント
レベルアップ実装後、2~3日見てなかった自分が悪い。
