### PR TITLE
separated_levelup_logic_from_controller_to_service

### DIFF
--- a/app/controllers/api/v1/levels_controller.rb
+++ b/app/controllers/api/v1/levels_controller.rb
@@ -16,26 +16,12 @@ module Api
       end
 
       def levelup
-        if @level.leveluped_at.nil? || (@level.leveluped_at.to_date.before? Date.today)
-          @level.leveluped_at = Date.today
-          @level.experience += 1
-        end
-        former_level = @level.current_level
-        case @level.experience
-        when 0 .. 2
-          @level.current_level = 1
-        when 3 .. 6
-          @level.current_level = 2
-        when 7 .. 13
-          @level.current_level = 3
+        LevelupService.new(@level).call
+        if @level.save!
+          render json: @level, status: :ok
         else
-          @level.current_level = 4
+          render json: @level, status: :bad_request
         end
-        if former_level != @level.current_level
-          @level.setting_level = @level.current_level
-        end
-        @level.save!
-        render json: @level
       end
 
       private

--- a/app/controllers/api/v1/oauths_controller.rb
+++ b/app/controllers/api/v1/oauths_controller.rb
@@ -32,10 +32,7 @@ module Api
         user_from_provider = build_from(provider)
         user = User.find_or_initialize_by(twitter_id: user_from_provider.twitter_id)
         user = user_from_provider if user.new_record?
-        user.build_authentication(uid: @user_hash[:uid],
-                                  provider:,
-                                  access_token: access_token.token,
-                                  access_token_secret: access_token.secret)
+        user.build_authentication(uid: @user_hash[:uid], provider:, access_token: access_token.token, access_token_secret: access_token.secret)
         user.save!
         reset_session
         auto_login(@user)

--- a/app/controllers/api/v1/results_controller.rb
+++ b/app/controllers/api/v1/results_controller.rb
@@ -36,8 +36,7 @@ module Api
       private
 
       def result_params
-        params.require(:result).permit(:user_id, :dragon_id, :score, :magnitude, :troversion,
-                                       :target_account, :screen_name)
+        params.require(:result).permit(:user_id, :dragon_id, :score, :magnitude, :troversion, :target_account, :screen_name)
       end
     end
   end

--- a/app/controllers/api/v1/user_settings_controller.rb
+++ b/app/controllers/api/v1/user_settings_controller.rb
@@ -5,10 +5,7 @@ module Api
 
       def update
         data = client.user(current_user.screen_name)
-        current_user.update!(name: data[:name],
-                             screen_name: data[:screen_name],
-                             twitter_id: data[:id],
-                             image: data[:profile_image_url_https])
+        current_user.update!(name: data[:name], screen_name: data[:screen_name], twitter_id: data[:id], image: data[:profile_image_url_https])
         render json: current_user, status: :ok
       end
 

--- a/app/services/levelup_service.rb
+++ b/app/services/levelup_service.rb
@@ -1,0 +1,26 @@
+class LevelupService
+  def initialize(level)
+    @level = level
+  end
+
+  def call
+    former_level = @level.current_level
+    if @level.leveluped_at.nil? || (@level.leveluped_at.to_date.before? Date.today)
+      @level.leveluped_at = Date.today
+      @level.experience += 1
+    end
+    case @level.experience
+    when 0 .. 2
+      @level.current_level = 1
+    when 3 .. 6
+      @level.current_level = 2
+    when 7 .. 13
+      @level.current_level = 3
+    else
+      @level.current_level = 4
+    end
+    if former_level != @level.current_level
+      @level.setting_level = @level.current_level
+    end
+  end
+end


### PR DESCRIPTION
## 概要
レベルアップ時のロジックをコントローラーに記載したままだったので、サービス層に分離した。
後、更新したlevelをsaveする時にifで分岐させて、エラーが出た場合は404が返されるように書き直した。

## コメント
今更感。
